### PR TITLE
Fix erroring out due to type mismatch

### DIFF
--- a/rgb-cooling-hat-display.py
+++ b/rgb-cooling-hat-display.py
@@ -111,7 +111,7 @@ def setOLEDshow():
     cmd = "free -m | awk 'NR==2{printf \"RAM:%s/%s MB \", $2-$3,$2}'"
     MemUsage = subprocess.check_output(cmd, shell = True)
 
-    cmd = "df -h | awk '$NF==\"/\"{printf \"Disk:%d/%dMB\", ($2-$3)*1024,$2*1024}'"
+    cmd = "df -h | awk '$NF==\"/\"{printf \"Disk:%d/%d MB\", ($2-$3)*1024,$2*1024}'"
     Disk = subprocess.check_output(cmd, shell = True)
 
     cmd = "hostname -I | awk '{ print $1 }'"
@@ -132,7 +132,7 @@ def setOLEDshow():
         time.sleep(.1)
     except:
         exc_tuple = sys.exc_info()
-        print("setoledshow [0]:" + exc_tuple[0] + " [1]:" + exc_tuple[1] + " [2]:" + exc_tuple[2])
+        print("setoledshow [0]:" + str(exc_tuple[0]) + " [1]:" + str(exc_tuple[1]) + " [2]:" + str(exc_tuple[2]))
 
 #setFanSpeed(0x00)
 #setRGBEffect(0x03)

--- a/rgb-cooling-hat-fan.py
+++ b/rgb-cooling-hat-fan.py
@@ -10,7 +10,7 @@ def setfanspeed(oVal):
         bus.write_byte_data(addr, fan_reg, oVal)
     except:
         exc_tuple = sys.exc_info()
-        print("setfanspeed [0]:" + exc_tuple[0] + " [1]:" + exc_tuple[1] + " [2]:" + exc_tuple[2])
+        print("setfanspeed [0]:" + str(exc_tuple[0]) + " [1]:" + str(exc_tuple[1]) + " [2]:" + str(exc_tuple[2]))
 
 def setRGBEffect(effect):
     try:
@@ -18,7 +18,7 @@ def setRGBEffect(effect):
             bus.write_byte_data(addr, rgb_effect_reg, effect&0xff)
     except:
         exc_tuple = sys.exc_info()
-        print("setRGBEffect [0]:" + exc_tuple[0] + " [1]:" + exc_tuple[1] + " [2]:" + exc_tuple[2])
+        print("setRGBEffect [0]:" + str(exc_tuple[0]) + " [1]:" + str(exc_tuple[1]) + " [2]:" + str(exc_tuple[2]))
 
 def setRGBSpeed(speed):
     try:
@@ -26,7 +26,7 @@ def setRGBSpeed(speed):
             bus.write_byte_data(addr, rgb_speed_reg, speed&0xff)
     except:
         exc_tuple = sys.exc_info()
-        print("setRGBSpeed [0]:" + exc_tuple[0] + " [1]:" + exc_tuple[1] + " [2]:" + exc_tuple[2])
+        print("setRGBSpeed [0]:" + str(exc_tuple[0]) + " [1]:" + str(exc_tuple[1]) + " [2]:" + str(exc_tuple[2]))
 
 def setRGBColor(color):
     try:
@@ -34,7 +34,7 @@ def setRGBColor(color):
             bus.write_byte_data(addr, rgb_color_reg, color&0xff)
     except:
         exc_tuple = sys.exc_info()
-        print("setRGBColor [0]:" + exc_tuple[0] + " [1]:" + exc_tuple[1] + " [2]:" + exc_tuple[2])
+        print("setRGBColor [0]:" + str(exc_tuple[0]) + " [1]:" + str(exc_tuple[1]) + " [2]:" + str(exc_tuple[2]))
 
 def setrgb(num,r,g,b):
     try:
@@ -52,7 +52,7 @@ def setrgb(num,r,g,b):
             bus.write_byte_data(addr,0x03,b&0xff)
     except:
         exc_tuple = sys.exc_info()
-        print("setrgb [0]:" + exc_tuple[0] + " [1]:" + exc_tuple[1] + " [2]:" + exc_tuple[2])
+        print("setrgb [0]:" + str(exc_tuple[0]) + " [1]:" + str(exc_tuple[1]) + " [2]:" + str(exc_tuple[2]))
 
 
 bus = smbus.SMBus(1)


### PR DESCRIPTION
<h1>Why the pull request is created</h1>
If the code errors out, when it tries to print out the error the code errors out <i>again</i> and spits this instead:

![Edited Scrot](https://github.com/milkmansson/yahboom-hat/assets/70095196/1f4f9795-cbe4-4a0d-90f3-7de93c3c1f59)
This pull request fixes the issue above and also add spacing for the disk display to make it consistent with ram display